### PR TITLE
feat: 🎸 UI refinements

### DIFF
--- a/Sources/SAPCAI/UI/Common/SwiftUI/CardSectionsView.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CardSectionsView.swift
@@ -28,6 +28,7 @@ struct CardSectionsView: View {
                         .padding([.leading], 16)
                 }
             }
+            .frame(minHeight: 44)
         }
     }
 }
@@ -94,7 +95,7 @@ extension CardSectionsView {
             return VStack(alignment: .leading, spacing: 3) {
                 if secAttribute.label != nil {
                     Text(secAttribute.label!)
-                        .font(.subheadline)
+                        .font(.body)
                         .foregroundColor(self.themeManager.color(for: .primary2))
                         .lineLimit(1)
                         .padding([.top], 10)

--- a/Sources/SAPCAI/UI/Common/SwiftUI/CarouselItemView.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CarouselItemView.swift
@@ -16,6 +16,7 @@ struct CarouselItemView: View {
                 }
                 if carouselItem!.itemButtons != nil {
                     CarouselButtonsView(buttonsData: carouselItem!.itemButtons)
+                        .frame(minHeight: 44)
                 }
             }
         }

--- a/Sources/SAPCAI/UI/Common/SwiftUI/View+Extensions.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/View+Extensions.swift
@@ -60,3 +60,14 @@ struct EdgeBorder: Shape {
         return path
     }
 }
+
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners,
+                                cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}

--- a/Sources/SAPCAI/UI/MessageView/ObjectCardMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ObjectCardMessageView.swift
@@ -32,7 +32,7 @@ struct ObjectCardMessageView: View {
                         .frame(width: 50, height: 50)
                 }
                 HStack(alignment: .firstTextBaseline) {
-                    VStack(alignment: .leading) {
+                    VStack(alignment: .leading, spacing: 6) {
                         if model.headline != nil {
                             Text(model.headline!)
                                 .font(.headline)
@@ -107,6 +107,7 @@ struct ObjectCardMessageView: View {
                             Divider().background(self.themeManager.color(for: .lineColor))
                         }
                     }
+                    .frame(minHeight: 44)
                 }
             }
         }

--- a/Sources/SAPCAI/UI/MessageView/ObjectMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ObjectMessageView.swift
@@ -33,7 +33,7 @@ struct ObjectMessageView: View {
                     .frame(width: 50, height: 50)
             }
             HStack(alignment: self.hasButtons && !self.hasStatus ? .center : .firstTextBaseline) {
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: 6) {
                     if model.headline != nil {
                         Text(model.headline!)
                             .font(.headline)

--- a/Sources/SAPCAI/UI/Modifiers/Modifiers.swift
+++ b/Sources/SAPCAI/UI/Modifiers/Modifiers.swift
@@ -15,7 +15,8 @@ func roundedBorder(for theme: CAITheme) -> some View {
 }
 
 func roundedBackground(for theme: CAITheme, key: Theme.Color.Key) -> some View {
-    RoundedRectangle(cornerRadius: theme.value(for: .cornerRadius, type: CGFloat.self, defaultValue: 8))
+    RoundedCorner(radius: theme.value(for: .cornerRadius, type: CGFloat.self, defaultValue: 8),
+                  corners: [.topLeft, .topRight, .bottomLeft])
         .fill(theme.color(for: key))
 }
 


### PR DESCRIPTION
Tiny fix for gap 6 7 8 15, left will be handled later.
<table>
    <tr>
        <td colspan="2", align="center">New Style</td>
    <tr>
    <tr>
        <td><img width="438" alt="Screen Shot 2021-08-09 at 11 21 03 AM" src="https://user-images.githubusercontent.com/33440079/128686772-eba0db29-1d17-4bed-8e29-ee3ca8ef68a0.png"></td>
        <td><img width="438" alt="Screen Shot 2021-08-09 at 11 21 26 AM" src="https://user-images.githubusercontent.com/33440079/128686801-a8d30273-e371-4b7c-81f2-071ec1a03fd0.png"></td>
    <tr>
</table>