### PR TITLE
fix: 🐛 resolve cycle reference for conversation operation

### DIFF
--- a/Sources/SAPCAI/Foundation/Networking/Internal/Operations.swift
+++ b/Sources/SAPCAI/Foundation/Networking/Internal/Operations.swift
@@ -56,8 +56,8 @@ class CAIConversationOperation: AsynchronousOperation {
     }
 
     override func execute() {
-        self.dataTask = self.jsonAPIDataTask(request: self.request, completionHandler: { result in
-
+        self.dataTask = self.jsonAPIDataTask(request: self.request, completionHandler: { [weak self] result in
+            guard let self = self else { return }
             self.finish()
 
             if self.isCancelled {
@@ -80,8 +80,11 @@ class CAIConversationOperation: AsynchronousOperation {
     func jsonAPIDataTask(request: APIRequest, completionHandler: @escaping ((Result<CAIResponseData, CAIError>) -> Void)) -> SAPURLSessionTask {
         let urlRequest = request.urlRequest(with: self.serviceConfig.baseURL)
         
-        return self.serviceConfig.urlSession.dataTask(with: urlRequest, completionHandler: { data, response, error in
-
+        return self.serviceConfig.urlSession.dataTask(with: urlRequest, completionHandler: { [weak self] data, response, error in
+            guard let self = self else {
+                completionHandler(.failure(.cancelled))
+                return
+            }
             if self.isCancelled {
                 completionHandler(.failure(.server(nil)))
                 return


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="1552" alt="Screen Shot 2021-08-10 at 4 01 00 PM" src="https://user-images.githubusercontent.com/33440079/128847071-91e964aa-8c03-4a31-92a9-cf7ae7fe7406.png">|<img width="1552" alt="Screen Shot 2021-08-10 at 4 08 15 PM" src="https://user-images.githubusercontent.com/33440079/128847086-39060b88-7606-4b67-a488-0732b167204d.png">|

Just fix cycle reference leak, there are still `CFString` leaks, which I have no idea what cause that.
I find it occurs when new message received from `messageSubscription` in `MessagingViewModel`.
And when chat view update, it appears in memory graph. I will check it later

Also there are massive `SwiftUI` leaks tracked in `Instruments`, but didn't showed in memory graph, I just ignored it.