### PR TITLE
feat: 🎸 update button background for selected state

### DIFF
--- a/Sources/SAPCAI/Foundation/Networking/Internal/Operations.swift
+++ b/Sources/SAPCAI/Foundation/Networking/Internal/Operations.swift
@@ -56,8 +56,8 @@ class CAIConversationOperation: AsynchronousOperation {
     }
 
     override func execute() {
-        self.dataTask = self.jsonAPIDataTask(request: self.request, completionHandler: { result in
-
+        self.dataTask = self.jsonAPIDataTask(request: self.request, completionHandler: { [weak self] result in
+            guard let self = self else { return }
             self.finish()
 
             if self.isCancelled {
@@ -80,8 +80,11 @@ class CAIConversationOperation: AsynchronousOperation {
     func jsonAPIDataTask(request: APIRequest, completionHandler: @escaping ((Result<CAIResponseData, CAIError>) -> Void)) -> SAPURLSessionTask {
         let urlRequest = request.urlRequest(with: self.serviceConfig.baseURL)
         
-        return self.serviceConfig.urlSession.dataTask(with: urlRequest, completionHandler: { data, response, error in
-
+        return self.serviceConfig.urlSession.dataTask(with: urlRequest, completionHandler: { [weak self] data, response, error in
+            guard let self = self else {
+                completionHandler(.failure(.cancelled))
+                return
+            }
             if self.isCancelled {
                 completionHandler(.failure(.server(nil)))
                 return

--- a/Sources/SAPCAI/Foundation/Theme/ThemeManager.swift
+++ b/Sources/SAPCAI/Foundation/Theme/ThemeManager.swift
@@ -275,6 +275,9 @@ public struct Theme {
 
             /// Information color
             public static let infoColor = Key(rawValue: "infoColor")
+            
+            /// default button selected state color
+            public static let buttonSelectedColor = Key(rawValue: "buttonSelectedColor")
         }
     }
 }

--- a/Sources/SAPCAI/Media.xcassets/default_buttonSelectedColor.colorset/Contents.json
+++ b/Sources/SAPCAI/Media.xcassets/default_buttonSelectedColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEF",
+          "green" : "0xEE",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA1",
+          "green" : "0x54",
+          "red" : "0x08"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SAPCAI/Media.xcassets/fiori_buttonSelectedColor.colorset/Contents.json
+++ b/Sources/SAPCAI/Media.xcassets/fiori_buttonSelectedColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.937",
+          "green" : "0.933",
+          "red" : "0.933"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.631",
+          "green" : "0.329",
+          "red" : "0.031"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sources/SAPCAI/UI/Common/SwiftUI/CardSectionsView.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CardSectionsView.swift
@@ -28,6 +28,7 @@ struct CardSectionsView: View {
                         .padding([.leading], 16)
                 }
             }
+            .frame(minHeight: 44)
         }
     }
 }
@@ -94,7 +95,7 @@ extension CardSectionsView {
             return VStack(alignment: .leading, spacing: 3) {
                 if secAttribute.label != nil {
                     Text(secAttribute.label!)
-                        .font(.subheadline)
+                        .font(.body)
                         .foregroundColor(self.themeManager.color(for: .primary2))
                         .lineLimit(1)
                         .padding([.top], 10)

--- a/Sources/SAPCAI/UI/Common/SwiftUI/CarouselItemView.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CarouselItemView.swift
@@ -16,6 +16,7 @@ struct CarouselItemView: View {
                 }
                 if carouselItem!.itemButtons != nil {
                     CarouselButtonsView(buttonsData: carouselItem!.itemButtons)
+                        .frame(minHeight: 44)
                 }
             }
         }

--- a/Sources/SAPCAI/UI/Common/SwiftUI/CarouselItemView.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CarouselItemView.swift
@@ -17,6 +17,7 @@ struct CarouselItemView: View {
                 if carouselItem!.itemButtons != nil {
                     CarouselButtonsView(buttonsData: carouselItem!.itemButtons)
                         .frame(minHeight: 44)
+                        .buttonStyle(PlainCellButtonStyle())
                 }
             }
         }

--- a/Sources/SAPCAI/UI/Common/SwiftUI/View+Extensions.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/View+Extensions.swift
@@ -60,3 +60,14 @@ struct EdgeBorder: Shape {
         return path
     }
 }
+
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners,
+                                cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}

--- a/Sources/SAPCAI/UI/MessageView/ButtonsMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ButtonsMessageView.swift
@@ -52,19 +52,22 @@ struct ButtonsMessageView: View {
                                 }
                                 if i == 4, self.buttons!.buttonsData!.count > showLessLen {
                                     Divider().background(self.themeManager.color(for: .lineColor))
-                                    Button(action: {
-                                        self.viewModel.contentHeight += 0
-                                        self.showMoreButtons = true
-                                    }, label: {
+                                    HStack {
                                         Spacer()
-                                        Text(Bundle.cai.localizedString(forKey: "View more", value: "View more", table: nil))
-                                            .font(.body)
-                                            .lineLimit(1)
-                                            .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+                                        Button(action: {
+                                            self.viewModel.contentHeight += 0
+                                            self.showMoreButtons = true
+                                        }, label: {
+                                            Text(Bundle.cai.localizedString(forKey: "View more", value: "View more", table: nil))
+                                                .font(.body)
+                                                .lineLimit(1)
+                                                .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+                                        })
                                         Spacer()
-                                    })
+                                    }
                                 }
                             }
+                            .buttonStyle(PlainCellButtonStyle())
                         }
                     }
                 }.background(roundedBorder(for: self.themeManager.theme))

--- a/Sources/SAPCAI/UI/MessageView/CarouselMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/CarouselMessageView.swift
@@ -79,7 +79,8 @@ struct CarouselMessageView: View {
     struct CarouselMessageView_Previews: PreviewProvider {
         static var previews: some View {
             GeometryReader { geometry in
-                CarouselMessageView(model: testData.model[0], geometry: geometry)
+                CarouselMessageView(model: PreviewData.carouselMessageData.model[0], geometry: geometry)
+                    .environmentObject(ThemeManager.shared)
             }
         }
     }

--- a/Sources/SAPCAI/UI/MessageView/ListMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ListMessageView.swift
@@ -101,6 +101,7 @@ struct ListMessageView: View {
                         })
                     }
                 }
+                .buttonStyle(PlainCellButtonStyle())
             }
         }
     }

--- a/Sources/SAPCAI/UI/MessageView/ObjectCardMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ObjectCardMessageView.swift
@@ -32,7 +32,7 @@ struct ObjectCardMessageView: View {
                         .frame(width: 50, height: 50)
                 }
                 HStack(alignment: .firstTextBaseline) {
-                    VStack(alignment: .leading) {
+                    VStack(alignment: .leading, spacing: 6) {
                         if model.headline != nil {
                             Text(model.headline!)
                                 .font(.headline)
@@ -107,6 +107,7 @@ struct ObjectCardMessageView: View {
                             Divider().background(self.themeManager.color(for: .lineColor))
                         }
                     }
+                    .frame(minHeight: 44)
                 }
             }
         }

--- a/Sources/SAPCAI/UI/MessageView/ObjectCardMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ObjectCardMessageView.swift
@@ -111,6 +111,7 @@ struct ObjectCardMessageView: View {
                 }
             }
         }
+        .buttonStyle(PlainCellButtonStyle())
         .background(roundedBorder(for: self.themeManager.theme))
     }
 }

--- a/Sources/SAPCAI/UI/MessageView/ObjectMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ObjectMessageView.swift
@@ -33,7 +33,7 @@ struct ObjectMessageView: View {
                     .frame(width: 50, height: 50)
             }
             HStack(alignment: self.hasButtons && !self.hasStatus ? .center : .firstTextBaseline) {
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: 6) {
                     if model.headline != nil {
                         Text(model.headline!)
                             .font(.headline)

--- a/Sources/SAPCAI/UI/MessageView/ObjectMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ObjectMessageView.swift
@@ -64,6 +64,7 @@ struct ObjectMessageView: View {
                             .frame(minWidth: 99, maxWidth: self.isPortrait ? 100 : 200, alignment: .trailing)
                     } else {
                         MultiButtonsView(buttons: self.model.objectButtons!)
+                            .buttonStyle(PlainCellButtonStyle())
                     }
                 } else {
                     VStack(alignment: .trailing, spacing: 6) {
@@ -96,6 +97,7 @@ struct ObjectMessageView: View {
                                     .frame(minWidth: 99, maxWidth: self.isPortrait ? 100 : 200, alignment: .trailing)
                             } else {
                                 MultiButtonsView(buttons: self.model.objectButtons!)
+                                    .buttonStyle(PlainCellButtonStyle())
                             }
                         }
                     }

--- a/Sources/SAPCAI/UI/Modifiers/Modifiers.swift
+++ b/Sources/SAPCAI/UI/Modifiers/Modifiers.swift
@@ -15,7 +15,8 @@ func roundedBorder(for theme: CAITheme) -> some View {
 }
 
 func roundedBackground(for theme: CAITheme, key: Theme.Color.Key) -> some View {
-    RoundedRectangle(cornerRadius: theme.value(for: .cornerRadius, type: CGFloat.self, defaultValue: 8))
+    RoundedCorner(radius: theme.value(for: .cornerRadius, type: CGFloat.self, defaultValue: 8),
+                  corners: [.topLeft, .topRight, .bottomLeft])
         .fill(theme.color(for: key))
 }
 

--- a/Sources/SAPCAI/UI/PreviewData.swift
+++ b/Sources/SAPCAI/UI/PreviewData.swift
@@ -58,7 +58,8 @@
             viewModel.addMessages(contentsOf: [responseData])
             return viewModel
         }
-
+        
+        /// for CardSectionsView
         static var cardSectionData: UIModelDataSection {
             func makeDataValue(label: String? = nil, value: String? = nil, dataType: String? = nil) -> UIModelDataValue {
                 UIModelDataValue(value: value, dataType: dataType, rawValue: nil, label: label, valueState: nil)
@@ -78,6 +79,35 @@
                                                 makeDataValue(label: "real address",
                                                               value: "1234, CA, USA",
                                                               dataType: "address")])
+        }
+        
+        /// for CarouselMessageView
+        static var carouselMessageData: MessagingViewModel {
+            let viewModel = MessagingViewModel(publisher: MockPublisher())
+            var carouselArr = [CAIResponseMessageData]()
+            var iButtons = [
+                UIModelDataAction("Submit review", "Submit review", .text)
+            ]
+            let c1 = CAIResponseMessageData("Mustang", "Car on race track", "https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/2019-mustang-shelby-gt350-101-1528733363.jpg?crop=0.817xw:1.00xh;0.149xw,0&resize=640:*", nil, iButtons, nil, nil, nil, nil, true)
+                
+            carouselArr.append(c1)
+            iButtons = [
+                UIModelDataAction("See more", "See more", .text)
+            ]
+            let c2 = CAIResponseMessageData("Dog", "Without the cutiest animal on the planet, am I right?", "https://thelabradorclub.com/wp-content/uploads/2016/09/purpose-bg.jpg", nil, iButtons, nil, nil, nil, nil, true)
+            
+            carouselArr.append(c2)
+            
+            let c3 = CAIResponseMessageData("Card", "Card in Carousel", nil, nil, iButtons, nil, nil, nil, nil, true)
+            
+            carouselArr.append(c3)
+            
+            let c4 = CAIResponseMessageData("Different Card", "Another Card in Carousel", nil, nil, iButtons, nil, nil, nil, nil, true)
+            
+            carouselArr.append(c4)
+            let fourPages = CAIResponseMessageData(carouselArr.map { $0.attachment.content! })
+            viewModel.addMessages(contentsOf: [fourPages])
+            return viewModel
         }
     }
 

--- a/Sources/SAPCAI/UI/Styles/Styles.swift
+++ b/Sources/SAPCAI/UI/Styles/Styles.swift
@@ -93,9 +93,9 @@ public struct CasualQuickReplyButtonStyle: ButtonStyle {
 /// Plain Button Style
 public struct PlainCellButtonStyle: ButtonStyle {
     @EnvironmentObject private var themeManager: ThemeManager
+    
     public func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
-            .font(.body)
             .background(configuration.isPressed ? self.themeManager.color(for: .buttonSelectedColor) : Color.clear)
             .foregroundColor(configuration.isPressed ? Color.accentColor.opacity(0.5) : Color.accentColor)
     }

--- a/Sources/SAPCAI/UI/Styles/Styles.swift
+++ b/Sources/SAPCAI/UI/Styles/Styles.swift
@@ -90,6 +90,17 @@ public struct CasualQuickReplyButtonStyle: ButtonStyle {
     }
 }
 
+/// Plain Button Style
+public struct PlainCellButtonStyle: ButtonStyle {
+    @EnvironmentObject private var themeManager: ThemeManager
+    public func makeBody(configuration: Self.Configuration) -> some View {
+        configuration.label
+            .font(.body)
+            .background(configuration.isPressed ? self.themeManager.color(for: .buttonSelectedColor) : Color.clear)
+            .foregroundColor(configuration.isPressed ? Color.accentColor.opacity(0.5) : Color.accentColor)
+    }
+}
+
 /// :nodoc:
 struct CAIFontCollection: FontCollection {
     // change font


### PR DESCRIPTION
Currently just update `CarouseMessageView` cell, I'm not sure if all buttons need be formatted to this style.
|Befor|After|
|-|-|
|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-12 at 15 34 44](https://user-images.githubusercontent.com/33440079/129156867-59660c85-ca70-4c6c-a4f0-282ec049d32a.png)|![Simulator Screen Shot - iPhone 12 Pro - 2021-08-12 at 15 13 33](https://user-images.githubusercontent.com/33440079/129156888-ec5dd9e9-4d08-4296-97b8-5bd1e8f25e9e.png)|
