### PR TITLE
fix: 🐛 carousel detail page with no status text crashes

### DIFF
--- a/Sources/SAPCAI/UI/Common/SwiftUI/CarouselDetailPage.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CarouselDetailPage.swift
@@ -117,26 +117,27 @@ struct CarouselDetailPage: View {
     
     @ViewBuilder var statusView: some View {
         if let itemHeader = carouselItem?.itemHeader,
-           let status = itemHeader.status
+           let status = itemHeader.status,
+           let statusText = status.value
         {
             if status.valState == .success {
-                Text(status.value!)
+                Text(statusText)
                     .font(.subheadline)
                     .foregroundColor(themeManager.color(for: .successColor))
             } else if status.valState == .error {
-                Text(status.value!)
+                Text(statusText)
                     .font(.subheadline)
                     .foregroundColor(themeManager.color(for: .errorColor))
             } else if status.valState == .warn {
-                Text(status.value!)
+                Text(statusText)
                     .font(.subheadline)
                     .foregroundColor(themeManager.color(for: .warnColor))
             } else if status.valState == .info {
-                Text(status.value!)
+                Text(statusText)
                     .font(.subheadline)
                     .foregroundColor(themeManager.color(for: .infoColor))
             } else {
-                Text(status.value!)
+                Text(statusText)
                     .font(.subheadline)
                     .foregroundColor(themeManager.color(for: .primary2))
             }


### PR DESCRIPTION
do not forcefully unwrap an optional