### PR TITLE
fix: 🐛 update carousel detail subtitle font size

### DIFF
--- a/Sources/SAPCAI/UI/Common/SwiftUI/CarouselDetailPage.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CarouselDetailPage.swift
@@ -60,13 +60,14 @@ struct CarouselDetailPage: View {
                 HStack {
                     Text(headline)
                         .font(.headline)
+                        .foregroundColor(themeManager.color(for: .primary1))
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Spacer()
                     statusView
                 }
                 Text(subheadline)
-                    .font(.subheadline)
-                    .foregroundColor(themeManager.color(for: .primary2))
+                    .font(.body)
+                    .foregroundColor(themeManager.color(for: .primary1))
                     .frame(maxWidth: .infinity, alignment: .leading)
                 if let carouselDesc = carouselItem?.itemHeader?.headerDescription {
                     Text(carouselDesc)


### PR DESCRIPTION
Update carousel subtitle font size to 17
<img width="458" alt="Screen Shot 2021-09-23 at 5 54 01 PM" src="https://user-images.githubusercontent.com/33440079/134487885-99c099e9-ada1-480a-bcce-743d06b4ab7a.png">
