### PR TITLE
feat: 🎸 add description for carousel card

### DIFF
--- a/Sources/SAPCAI/Foundation/Model/MessageTypeData.swift
+++ b/Sources/SAPCAI/Foundation/Model/MessageTypeData.swift
@@ -79,8 +79,6 @@ public protocol HeaderMessageData {
     var imageUrl: String? { get }
     
     var status: ValueData? { get }
-    
-    var headerDescription: String? { get }
 }
 
 /// Protocol describing a list

--- a/Sources/SAPCAI/Foundation/Model/UIModelData.swift
+++ b/Sources/SAPCAI/Foundation/Model/UIModelData.swift
@@ -513,10 +513,6 @@ extension UIModelDataHeader: HeaderMessageData {
     public var status: ValueData? {
         self.status1
     }
-    
-    public var headerDescription: String? {
-        self.description?.value
-    }
 }
 
 extension UIModelData: ListMessageData {

--- a/Sources/SAPCAI/UI/Common/SwiftUI/CarouselDetailPage.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CarouselDetailPage.swift
@@ -117,31 +117,8 @@ struct CarouselDetailPage: View {
     }
     
     @ViewBuilder var statusView: some View {
-        if let itemHeader = carouselItem?.itemHeader,
-           let status = itemHeader.status,
-           let statusText = status.value
-        {
-            if status.valState == .success {
-                Text(statusText)
-                    .font(.subheadline)
-                    .foregroundColor(themeManager.color(for: .successColor))
-            } else if status.valState == .error {
-                Text(statusText)
-                    .font(.subheadline)
-                    .foregroundColor(themeManager.color(for: .errorColor))
-            } else if status.valState == .warn {
-                Text(statusText)
-                    .font(.subheadline)
-                    .foregroundColor(themeManager.color(for: .warnColor))
-            } else if status.valState == .info {
-                Text(statusText)
-                    .font(.subheadline)
-                    .foregroundColor(themeManager.color(for: .infoColor))
-            } else {
-                Text(statusText)
-                    .font(.subheadline)
-                    .foregroundColor(themeManager.color(for: .primary2))
-            }
+        if let status = carouselItem?.itemHeader?.status {
+            ItemStatus(status: status)
         }
     }
     

--- a/Sources/SAPCAI/UI/Common/SwiftUI/CarouselDetailPage.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CarouselDetailPage.swift
@@ -69,7 +69,7 @@ struct CarouselDetailPage: View {
                     .font(.body)
                     .foregroundColor(themeManager.color(for: .primary1))
                     .frame(maxWidth: .infinity, alignment: .leading)
-                if let carouselDesc = carouselItem?.itemHeader?.headerDescription {
+                if let carouselDesc = carouselItem?.itemHeader?.footnote {
                     Text(carouselDesc)
                         .font(.subheadline)
                         .foregroundColor(themeManager.color(for: .primary2))

--- a/Sources/SAPCAI/UI/Common/SwiftUI/ItemStatus.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/ItemStatus.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct ItemStatus: View {
+    @EnvironmentObject private var themeManager: ThemeManager
+
+    let status: ValueData
+    
+    var body: some View {
+        if let statusText = status.value {
+            if status.valState == .success {
+                Text(statusText)
+                    .font(.subheadline)
+                    .foregroundColor(themeManager.color(for: .successColor))
+            } else if status.valState == .error {
+                Text(statusText)
+                    .font(.subheadline)
+                    .foregroundColor(themeManager.color(for: .errorColor))
+            } else if status.valState == .warn {
+                Text(statusText)
+                    .font(.subheadline)
+                    .foregroundColor(themeManager.color(for: .warnColor))
+            } else if status.valState == .info {
+                Text(statusText)
+                    .font(.subheadline)
+                    .foregroundColor(themeManager.color(for: .infoColor))
+            } else {
+                Text(statusText)
+                    .font(.subheadline)
+                    .foregroundColor(themeManager.color(for: .primary2))
+            }
+        } else {
+            EmptyView()
+        }
+    }
+}
+
+struct ItemStatus_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            ItemStatus(status: UIModelDataValue(value: "success",
+                                                dataType: "text",
+                                                rawValue: "status",
+                                                label: "stat",
+                                                valueState: "success"))
+            ItemStatus(status: UIModelDataValue(value: "error",
+                                                dataType: "text",
+                                                rawValue: "status",
+                                                label: "stat",
+                                                valueState: "error"))
+            ItemStatus(status: UIModelDataValue(value: "warn",
+                                                dataType: "text",
+                                                rawValue: "status",
+                                                label: "stat",
+                                                valueState: "warn"))
+            ItemStatus(status: UIModelDataValue(value: "info",
+                                                dataType: "text",
+                                                rawValue: "status",
+                                                label: "stat",
+                                                valueState: "info"))
+            ItemStatus(status: UIModelDataValue(value: "else",
+                                                dataType: "text",
+                                                rawValue: "status",
+                                                label: "stat",
+                                                valueState: "else"))
+        }
+        .environmentObject(ThemeManager.shared)
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/Sources/SAPCAI/UI/MessageView/HeaderMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/HeaderMessageView.swift
@@ -30,10 +30,16 @@ struct HeaderMessageView: View {
                         .frame(width: 50, height: 50)
                 }
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(model.headline ?? "-")
-                        .lineLimit(1)
-                        .font(.headline)
-                        .foregroundColor(themeManager.color(for: .primary1))
+                    HStack(alignment: .top, spacing: 0) {
+                        Text(model.headline ?? "-")
+                            .lineLimit(1)
+                            .font(.headline)
+                            .foregroundColor(themeManager.color(for: .primary1))
+                        if let status = model.status {
+                            Spacer()
+                            ItemStatus(status: status)
+                        }
+                    }
                     Text(model.subheadline ?? "-")
                         .lineLimit(1)
                         .font(.body)

--- a/Sources/SAPCAI/UI/MessageView/HeaderMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/HeaderMessageView.swift
@@ -36,12 +36,12 @@ struct HeaderMessageView: View {
                         .foregroundColor(themeManager.color(for: .primary1))
                     Text(model.subheadline ?? "-")
                         .lineLimit(1)
-                        .font(.subheadline)
+                        .font(.body)
                         .foregroundColor(themeManager.color(for: .primary2))
-                    if model.footnote != nil {
-                        Text(model.footnote!)
+                    if let footnote = model.footnote {
+                        Text(footnote)
                             .lineLimit(1)
-                            .font(.caption)
+                            .font(.subheadline)
                             .foregroundColor(themeManager.color(for: .primary2))
                     }
                 }

--- a/Sources/SAPCAI/UI/MessageView/ObjectCardMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ObjectCardMessageView.swift
@@ -59,28 +59,8 @@ struct ObjectCardMessageView: View {
                     Spacer()
                     
                     VStack(alignment: .trailing) {
-                        if model.status != nil, model.status!.value != nil {
-                            if model.status!.valState == .success {
-                                Text(model.status!.value!)
-                                    .font(.subheadline)
-                                    .foregroundColor(themeManager.color(for: .successColor))
-                            } else if model.status!.valState == .error {
-                                Text(model.status!.value!)
-                                    .font(.subheadline)
-                                    .foregroundColor(themeManager.color(for: .errorColor))
-                            } else if model.status!.valState == .warn {
-                                Text(model.status!.value!)
-                                    .font(.subheadline)
-                                    .foregroundColor(themeManager.color(for: .warnColor))
-                            } else if model.status!.valState == .info {
-                                Text(model.status!.value!)
-                                    .font(.subheadline)
-                                    .foregroundColor(themeManager.color(for: .infoColor))
-                            } else {
-                                Text(model.status!.value!)
-                                    .font(.subheadline)
-                                    .foregroundColor(themeManager.color(for: .primary2))
-                            }
+                        if let status = model.status {
+                            ItemStatus(status: status)
                         }
                         if model.substatus != nil {
                             Text(model.substatus!)

--- a/Sources/SAPCAI/UI/MessageView/ObjectMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ObjectMessageView.swift
@@ -67,28 +67,8 @@ struct ObjectMessageView: View {
                     }
                 } else {
                     VStack(alignment: .trailing, spacing: 6) {
-                        if self.hasStatus {
-                            if model.status!.valState == .success {
-                                Text(model.status!.value!)
-                                    .font(.subheadline)
-                                    .foregroundColor(themeManager.color(for: .successColor))
-                            } else if model.status!.valState == .error {
-                                Text(model.status!.value!)
-                                    .font(.subheadline)
-                                    .foregroundColor(themeManager.color(for: .errorColor))
-                            } else if model.status!.valState == .warn {
-                                Text(model.status!.value!)
-                                    .font(.subheadline)
-                                    .foregroundColor(themeManager.color(for: .warnColor))
-                            } else if model.status!.valState == .info {
-                                Text(model.status!.value!)
-                                    .font(.subheadline)
-                                    .foregroundColor(themeManager.color(for: .infoColor))
-                            } else {
-                                Text(model.status!.value!)
-                                    .font(.subheadline)
-                                    .foregroundColor(themeManager.color(for: .primary2))
-                            }
+                        if self.hasStatus, let status = model.status {
+                            ItemStatus(status: status)
                         }
                         if self.hasButtons {
                             if model.objectButtons!.count == 1 {


### PR DESCRIPTION
I remove `headerDescription` which is same as footnote.
By design, I update footnote font size to `subheadline` which is implemented already
|simulator|status preview|
|-|-|
|![Simulator Screen Shot - iPhone 12 Pro - 2021-09-28 at 10 37 05](https://user-images.githubusercontent.com/33440079/135014771-99cc5b76-1bcf-4a32-abfc-0625c80c10ef.png)|<img width="269" alt="Screen Shot 2021-09-28 at 10 45 21 AM" src="https://user-images.githubusercontent.com/33440079/135014705-9ea3c13c-f999-49d3-ab98-282ce5270543.png">|
