### PR TITLE
fix: 🐛 carousel control image: blue overlay on iOS 13

### DIFF
--- a/Sources/SAPCAI/UI/Common/SwiftUI/CarouselItemView.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CarouselItemView.swift
@@ -20,6 +20,7 @@ struct CarouselItemView: View {
                         }
                     }
                 }
+                .buttonStyle(PlainButtonStyle()) // needed for iOS 13 to avoid whole image will be be covered with an opaque blue color, see https://www.hackingwithswift.com/quick-start/swiftui/how-to-disable-the-overlay-color-for-images-inside-button-and-navigationlink
                 if let buttonsData = item.itemButtons {
                     CarouselButtonsView(buttonsData: buttonsData)
                         .frame(minHeight: 44)


### PR DESCRIPTION
tested with iOS 13.7 simulator and Xcode 13

|Before|After|
|---|---|
| ![Simulator Screen Shot - IPhone 11 (13 7) - 2021-09-29 at 14 23 30](https://user-images.githubusercontent.com/4176826/135351305-e5cd06eb-17b9-428c-a878-0f0ba6930477.png)|![Simulator Screen Shot - IPhone 11 (13 7) - 2021-09-29 at 14 24 53](https://user-images.githubusercontent.com/4176826/135351336-e68272b8-76de-4084-bd96-094fd9d129be.png)|

Also works for iOS 15 Simulator and Xcode 13