### PR TITLE
fix: 🐛 CAITestApp: new conversation if card details were viewed

### DIFF
--- a/CAITestApp/CAITestApp/HomeView.swift
+++ b/CAITestApp/CAITestApp/HomeView.swift
@@ -185,9 +185,7 @@ struct HomeView: View {
                         .navigationBarTitle(Text(self.liveConnection.channelSlug), displayMode: .inline)
                         .environmentObject(self.dataModel.getModelFor(self.liveConnection))
                         .environmentObject(ThemeManager.shared)
-                        .onDisappear {
-                            self.dataModel.clear()
-                        })) {
+                )) {
                     Text("Connect")
                 }
             } else {


### PR DESCRIPTION
related to 91c243c but this time for "Explicit" channel selection