### PR TITLE
fix: 🐛 decoding error when loading channel preferences/menu

### DIFF
--- a/Sources/SAPCAI/Foundation/Model/CAIChannelPreferences.swift
+++ b/Sources/SAPCAI/Foundation/Model/CAIChannelPreferences.swift
@@ -28,7 +28,7 @@ public struct CAIChannelPreferencesMenuData: Decodable {
 /// Holds model for a channel menu object
 public struct CAIChannelMenuData: Decodable {
     var locale: String
-    var call_to_actions: [CAIChannelMenuDataAction]
+    var call_to_actions: [CAIChannelMenuDataAction]?
 
     /// Initializer
     public init(_ locale: String, _ callToActions: [CAIChannelMenuDataAction]) {
@@ -39,15 +39,18 @@ public struct CAIChannelMenuData: Decodable {
 
 /// Holds model for a channel menu call to actions
 public struct CAIChannelMenuDataAction: Decodable {
-    let id: String
+    var id: String = UUID().uuidString
     var title: String
     var type: String
     var payload: String?
     var call_to_actions: [CAIChannelMenuDataAction]?
 
+    private enum CodingKeys: String, CodingKey {
+        case title, type, payload, call_to_actions
+    }
+
     /// Initializer
     public init(_ title: String, _ type: String, _ payload: String?, _ callToActions: [CAIChannelMenuDataAction]?) {
-        self.id = UUID().uuidString
         self.title = title
         self.type = type
         self.payload = payload
@@ -93,7 +96,8 @@ extension CAIChannelPreferencesMenuData: PreferencesMenuData {
 extension CAIChannelMenuData: MenuData {
     /// menu actions
     public var menuActions: [MenuAction] {
-        self.call_to_actions
+        guard let actions = self.call_to_actions else { return [] }
+        return actions
     }
 }
 

--- a/Sources/SAPCAI/Foundation/Service/CAIChannelService.swift
+++ b/Sources/SAPCAI/Foundation/Service/CAIChannelService.swift
@@ -120,7 +120,7 @@ public final class CAIChannelService: ObservableObject {
 
                 result = .success(prefs.results)
             } catch {
-                self.logger.error("Unable to parse preferences from data \(data.toString)")
+                self.logger.error("Unable to parse preferences from data \(data.toString) due to error \(error.localizedDescription)")
                 result = .failure(error)
             }
             

--- a/Sources/SAPCAI/Foundation/Theme/ThemeManager.swift
+++ b/Sources/SAPCAI/Foundation/Theme/ThemeManager.swift
@@ -22,7 +22,7 @@ public enum CAITheme: CustomStringConvertible {
     /// **No longer maintained!** Use the standard Fiori theme or a custom theme
     case casual(ColorPalette)
 
-    ///Fiori theme follows SAP Fiori Design Language
+    /// Fiori theme follows SAP Fiori Design Language
     case fiori(ColorPalette)
 
     case custom(Theme, ColorPalette)


### PR DESCRIPTION
persistent static menu for channel, as specified by bot developer in
bot's user channels, will now be rendered if you used
`CAIChannelService.loadPreferences` and passed the result in
`MessagingViewModel.menu`

✅ Closes: #64
