### PR TITLE
Fix fatal exceptions

### DIFF
--- a/Sources/SAPCAI/UI/Common/SwiftUI/ListItemView.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/ListItemView.swift
@@ -2,11 +2,15 @@ import Foundation
 import SwiftUI
 
 struct ListItemView: View {
+    @EnvironmentObject private var viewModel: MessagingViewModel
+
     var model: ObjectMessageData
 
     var body: some View {
         NavigationLink(destination: CardPageView(card: model)
-            .environmentObject(ThemeManager.shared)) {
+            .environmentObject(ThemeManager.shared)
+            .environmentObject(self.viewModel)
+        ) {
             ObjectMessageView(model: model)
         }
     }
@@ -18,6 +22,7 @@ struct ListItemView: View {
             ListItemView(model: PreviewData.objectMessage.first!)
                 .previewLayout(.sizeThatFits)
                 .environmentObject(ThemeManager.shared)
+                .environmentObject(testData)
         }
     }
 #endif

--- a/Sources/SAPCAI/UI/MessageView/ObjectMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ObjectMessageView.swift
@@ -41,7 +41,7 @@ struct ObjectMessageView: View {
                             .lineLimit(3)
                             .fixedSize(horizontal: false, vertical: true)
                     }
-                    if model.headline != nil {
+                    if model.subheadline != nil {
                         Text(model.subheadline!)
                             .font(.body)
                             .foregroundColor(themeManager.color(for: .primary2))


### PR DESCRIPTION
- fix runtime exception in ObjectMesssageView. Occurs when subheadline is missing (but is forcefully unwrapped)
- fix runtime exception in Card Details. Occurs when card was presented from list and user clicks on a button