### PR TITLE
fix: 🐛 Card Details: show section even its title is missing

### DIFF
--- a/CAITestApp/CAITestApp/MockData.swift
+++ b/CAITestApp/CAITestApp/MockData.swift
@@ -171,7 +171,17 @@ struct MockData {
         iButtons = [
             UIModelDataAction("Submit review", "Submit review", .text)
         ]
-        var c1 = CAIResponseMessageData(title: "Mustang", subtitle: "Car on race track", featuredImageName: "https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/2019-mustang-shelby-gt350-101-1528733363.jpg?crop=0.817xw:1.00xh;0.149xw,0&resize=640:*", inlineButtons: iButtons)
+        var c1 = CAIResponseMessageData(
+            title: "Mustang",
+            subtitle: "Car on race track",
+            featuredImageName: "https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/2019-mustang-shelby-gt350-101-1528733363.jpg?crop=0.817xw:1.00xh;0.149xw,0&resize=640:*",
+            inlineButtons: iButtons,
+            sections: [
+                UIModelDataSection(nil, [
+                    UIModelDataValue(value: "High", dataType: "text", rawValue: "Very Cool", label: "Wow Factor", valueState: nil)
+                ])
+            ]
+        )
             
         carouselArr.append(c1)
         iButtons = [

--- a/Sources/SAPCAI/UI/Common/SwiftUI/CardPageView.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CardPageView.swift
@@ -103,13 +103,14 @@ struct CardPageView: View {
     @ViewBuilder var attributesTable: some View {
         if let sections = card?.cardSections,
            !sections.isEmpty,
-           let attributeTitle = sections[0].title,
            let attributes = sections[0].attributes
         {
             let groupedAttributes = convertAttributes(attributes)
-            Text(attributeTitle)
-                .font(.headline)
-                .padding([.leading, .trailing], 20)
+            if let attributeTitle = sections[0].title {
+                Text(attributeTitle)
+                    .font(.headline)
+                    .padding([.leading, .trailing], 20)
+            }
             
             VStack(spacing: 16) {
                 ForEach(groupedAttributes) {


### PR DESCRIPTION
Previously a section was displayed if a section title exists (at least
an empty string). Now the section will be displayed without a section
title if such title was not specified. No placeholder will be shown.

Example of a card details page without section title

![Example without section title](https://user-images.githubusercontent.com/4176826/160202610-7d910b20-b94e-4058-a287-59b687d2b5b6.png)


Example of a card details page with section title

![Example with section title](https://user-images.githubusercontent.com/4176826/160202605-8dd5d93d-ddf7-4175-b913-c9fcfdee2414.png)

