### PR TITLE
fix: 🐛 List Header & Card: remove superfluous placeholder

### DIFF
--- a/CAITestApp/CAITestApp/MockData.swift
+++ b/CAITestApp/CAITestApp/MockData.swift
@@ -197,9 +197,13 @@ struct MockData {
         
         carouselArr.append(c3)
         
-        var c4 = CAIResponseMessageData(title: "Simplest card", subtitle: "Card in Carousel without image/icon")
+        var c4 = CAIResponseMessageData(title: "A simple card", subtitle: "No image/icon", description: "Desc/Footnote")
         
         carouselArr.append(c4)
+
+        var c5 = CAIResponseMessageData(title: "A simple card", subtitle: nil, description: "Just Desc/Footnote", status1: "Status")
+
+        carouselArr.append(c5)
         
         arr.append(CAIResponseMessageData(carouselArr.map { $0.attachment.content! }, true))
 

--- a/Sources/SAPCAI/Foundation/Model/CAIResponseData.swift
+++ b/Sources/SAPCAI/Foundation/Model/CAIResponseData.swift
@@ -225,8 +225,8 @@ public extension CAIResponseMessageData {
     }
 
     @available(*, deprecated, message: "Use init(title:subtitle:headerImageName:contentPictureName:description:inlineButtons:sections:status1:status1ValueState:status2:status3:isBot)")
-    init(_ title: String,
-         _ subtitle: String,
+    init(_ title: String? = nil,
+         _ subtitle: String? = nil,
          _ headerImageName: String? = nil, // e.g. image in object card
          _ contentPictureName: String? = nil, // e.g. image for carousel card
          _ description: String? = nil,
@@ -299,8 +299,8 @@ public extension CAIResponseMessageData {
                   receivedAt: Date())
     }
 
-    init(title: String,
-         subtitle: String,
+    init(title: String? = nil,
+         subtitle: String? = nil,
          headerImageName: String? = nil, // e.g. image in object card
          featuredImageName: String? = nil, // e.g. image for carousel card
          description: String? = nil,
@@ -410,7 +410,7 @@ public extension CAIResponseMessageData {
                   receivedAt: Date())
     }
     
-    init(_ mockData: [UIModelDataContent], _ inlineButtons: [UIModelDataAction]? = nil, _ title: String, _ subtitle: String, _ description: String? = nil, _ isBot: Bool = true) {
+    init(_ mockData: [UIModelDataContent], _ inlineButtons: [UIModelDataAction]? = nil, _ title: String?, _ subtitle: String?, _ description: String? = nil, _ isBot: Bool = true) {
         var content = UIModelDataContent()
         content.list = mockData
         content.header = UIModelDataHeader(title: UIModelDataValue(value: title,

--- a/Sources/SAPCAI/Foundation/Model/UIModelData.swift
+++ b/Sources/SAPCAI/Foundation/Model/UIModelData.swift
@@ -584,3 +584,47 @@ extension UIModelDataMedia: MediaItem {
         CGSize(width: CGFloat(self.iWidth), height: CGFloat(self.iHeight))
     }
 }
+
+#if DEBUG
+    struct UIModelDataValueOptions: OptionSet {
+        let rawValue: Int
+
+        static let title = UIModelDataValueOptions(rawValue: 1 << 0)
+        static let subtitle = UIModelDataValueOptions(rawValue: 1 << 1)
+        static let description = UIModelDataValueOptions(rawValue: 1 << 2)
+        static let status1 = UIModelDataValueOptions(rawValue: 1 << 3)
+
+        static let all: UIModelDataValueOptions = [.title, .subtitle, .description, .status1]
+    }
+
+    extension UIModelDataHeader {
+        init(options: UIModelDataValueOptions) {
+            var titleDataValue: UIModelDataValue?
+            if options.contains(.title) {
+                titleDataValue = UIModelDataValue(text: "Title")
+            }
+            var subTitleDataValue: UIModelDataValue?
+            if options.contains(.subtitle) {
+                subTitleDataValue = UIModelDataValue(text: "SubTitle")
+            }
+            var descriptionDataValue: UIModelDataValue?
+            if options.contains(.description) {
+                descriptionDataValue = UIModelDataValue(text: "Description")
+            }
+            var status1DataValue: UIModelDataValue?
+            if options.contains(.status1) {
+                status1DataValue = UIModelDataValue(text: "Status")
+            }
+            self.init(title: titleDataValue,
+                      subtitle: subTitleDataValue,
+                      description: descriptionDataValue,
+                      status1: status1DataValue)
+        }
+    }
+
+    extension UIModelDataValue {
+        init(text: String) {
+            self.init(value: text, dataType: UIModelData.ValueType.text.rawValue, rawValue: nil, label: nil, valueState: nil)
+        }
+    }
+#endif

--- a/Sources/SAPCAI/UI/Common/SwiftUI/CardPageView.swift
+++ b/Sources/SAPCAI/UI/Common/SwiftUI/CardPageView.swift
@@ -49,10 +49,7 @@ struct CardPageView: View {
     }
     
     @ViewBuilder var header: some View {
-        if let itemHeader = card?.cardHeader,
-           let headline = itemHeader.headline,
-           let subheadline = itemHeader.subheadline
-        {
+        if let itemHeader = card?.cardHeader {
             HStack(alignment: .top) {
                 if let imageUrl = itemHeader.imageUrl,
                    let imageURL = URL(string: imageUrl)
@@ -63,17 +60,21 @@ struct CardPageView: View {
                 }
                 VStack(alignment: .leading, spacing: 8) {
                     HStack {
-                        Text(headline)
-                            .font(.headline)
-                            .foregroundColor(themeManager.color(for: .primary1))
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        if let headline = itemHeader.headline {
+                            Text(headline)
+                                .font(.headline)
+                                .foregroundColor(themeManager.color(for: .primary1))
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                         Spacer()
                         statusView
                     }
-                    Text(subheadline)
-                        .font(.body)
-                        .foregroundColor(themeManager.color(for: .primary1))
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    if let subheadline = itemHeader.subheadline {
+                        Text(subheadline)
+                            .font(.body)
+                            .foregroundColor(themeManager.color(for: .primary1))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                     if let carouselDesc = card?.cardHeader?.footnote {
                         Text(carouselDesc)
                             .font(.subheadline)

--- a/Sources/SAPCAI/UI/MessageView/HeaderMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/HeaderMessageView.swift
@@ -29,34 +29,40 @@ struct HeaderMessageView: View {
                     ImageView(imageUrl: imageUrl!)
                         .frame(width: 50, height: 50)
                 }
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(alignment: .top, spacing: 0) {
-                        Text(model.headline ?? "-")
-                            .lineLimit(1)
-                            .font(.headline)
-                            .foregroundColor(themeManager.color(for: .primary1))
+                HStack(alignment: .firstTextBaseline) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        if let headline = model.headline {
+                            Text(headline)
+                                .lineLimit(1)
+                                .font(.headline)
+                                .foregroundColor(themeManager.color(for: .primary1))
+                        }
+                        if let subheadline = model.subheadline {
+                            Text(subheadline)
+                                .lineLimit(1)
+                                .font(.body)
+                                .foregroundColor(themeManager.color(for: .primary2))
+                        }
+                        if let footnote = model.footnote {
+                            Text(footnote)
+                                .lineLimit(1)
+                                .font(.subheadline)
+                                .foregroundColor(themeManager.color(for: .primary2))
+                        }
+                    }
+                    Spacer()
+
+                    VStack(alignment: .trailing) {
+                        if listItemCount != nil && total != nil {
+                            Text("\(listItemCount!) of \(total!)")
+                                .lineLimit(1)
+                                .font(.subheadline)
+                                .foregroundColor(themeManager.color(for: .primary2))
+                        }
                         if let status = model.status {
-                            Spacer()
                             ItemStatus(status: status)
                         }
                     }
-                    Text(model.subheadline ?? "-")
-                        .lineLimit(1)
-                        .font(.body)
-                        .foregroundColor(themeManager.color(for: .primary2))
-                    if let footnote = model.footnote {
-                        Text(footnote)
-                            .lineLimit(1)
-                            .font(.subheadline)
-                            .foregroundColor(themeManager.color(for: .primary2))
-                    }
-                }
-                Spacer()
-                if listItemCount != nil && total != nil {
-                    Text("\(listItemCount!) of \(total!)")
-                        .lineLimit(1)
-                        .font(.subheadline)
-                        .foregroundColor(themeManager.color(for: .primary2))
                 }
             }
             .padding(16)
@@ -69,13 +75,54 @@ struct HeaderMessageView: View {
 #if DEBUG
     struct HeaderMessageView_Previews: PreviewProvider {
         static var previews: some View {
-            HeaderMessageView(model: UIModelDataHeader(title: UIModelDataValue(value: "title1", dataType: UIModelData.ValueType.text.rawValue,
-                                                                               rawValue: nil,
-                                                                               label: nil,
-                                                                               valueState: nil), subtitle: UIModelDataValue(value: "subtitle1", dataType: UIModelData.ValueType.text.rawValue,
-                                                                                                                            rawValue: nil,
-                                                                                                                            label: nil,
-                                                                                                                            valueState: nil), description: nil), listItemCount: nil, listTotal: nil).environmentObject(ThemeManager.shared)
+            Group {
+                HeaderMessageView(model: UIModelDataHeader(options: [.title, .subtitle, .description]),
+                                  listItemCount: "5",
+                                  listTotal: 10)
+                    .previewDisplayName("List Header")
+
+                HeaderMessageView(model: UIModelDataHeader(options: .all),
+                                  listItemCount: nil,
+                                  listTotal: nil)
+                    .previewDisplayName("Card Header")
+
+                HeaderMessageView(model: UIModelDataHeader(options: .all),
+                                  listItemCount: "5",
+                                  listTotal: 10)
+                    .previewDisplayName("Mixing List Info & Status will probably never happen")
+
+                HeaderMessageView(model: UIModelDataHeader(options: [.title, .subtitle, .status1]),
+                                  listItemCount: nil,
+                                  listTotal: nil)
+                    .previewDisplayName("No Description")
+
+                HeaderMessageView(model: UIModelDataHeader(options: [.title, .description, .status1]),
+                                  listItemCount: nil,
+                                  listTotal: nil)
+                    .previewDisplayName("No Subtitle")
+
+                HeaderMessageView(model: UIModelDataHeader(options: [.title]),
+                                  listItemCount: nil,
+                                  listTotal: nil)
+                    .previewDisplayName("Only Title")
+
+                HeaderMessageView(model: UIModelDataHeader(options: [.subtitle, .status1]),
+                                  listItemCount: nil,
+                                  listTotal: nil)
+                    .previewDisplayName("Subtitle and Status shall be on the same line if Title is missing")
+
+                HeaderMessageView(model: UIModelDataHeader(options: [.description, .status1]),
+                                  listItemCount: nil,
+                                  listTotal: nil)
+                    .previewDisplayName("Description and Status shall be on the same line if Title & Subtitle are missing")
+
+                HeaderMessageView(model: UIModelDataHeader(options: [.description]),
+                                  listItemCount: nil,
+                                  listTotal: nil)
+                    .previewDisplayName("Only Description")
+            }
+            .environmentObject(ThemeManager.shared)
+            .previewLayout(.sizeThatFits)
         }
     }
 #endif

--- a/Sources/SAPCAI/UI/MessageView/ListMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ListMessageView.swift
@@ -120,25 +120,20 @@ struct ListMessageView: View {
         static var previews: some View {
             Group {
                 ListMessageView(model: ListMessageView_Previews.previewData(items: 2, hasFooterButton: false))
-                    .environmentObject(ThemeManager.shared)
                     .previewDisplayName("Few items")
-                    .previewLayout(.sizeThatFits)
 
                 ListMessageView(model: ListMessageView_Previews.previewData(items: 2, hasFooterButton: true))
-                    .environmentObject(ThemeManager.shared)
                     .previewDisplayName("Few items with footer")
-                    .previewLayout(.sizeThatFits)
 
                 ListMessageView(model: ListMessageView_Previews.previewData(items: 15, hasFooterButton: false))
-                    .environmentObject(ThemeManager.shared)
                     .previewDisplayName("Lots of items items")
-                    .previewLayout(.sizeThatFits)
 
                 ListMessageView(model: ListMessageView_Previews.previewData(items: 15, hasFooterButton: true))
-                    .environmentObject(ThemeManager.shared)
                     .previewDisplayName("Lots of items items with footer")
-                    .previewLayout(.sizeThatFits)
             }
+            .environmentObject(MessagingViewModel(publisher: MockPublisher()))
+            .environmentObject(ThemeManager.shared)
+            .previewLayout(.sizeThatFits)
         }
     }
 #endif

--- a/Sources/SAPCAI/UI/MessageView/ObjectCardMessageView.swift
+++ b/Sources/SAPCAI/UI/MessageView/ObjectCardMessageView.swift
@@ -33,22 +33,22 @@ struct ObjectCardMessageView: View {
                 }
                 HStack(alignment: .firstTextBaseline) {
                     VStack(alignment: .leading, spacing: 6) {
-                        if model.headline != nil {
-                            Text(model.headline!)
+                        if let headline = model.headline {
+                            Text(headline)
                                 .font(.headline)
                                 .foregroundColor(themeManager.color(for: .primary1))
                                 .lineLimit(3)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
-                        if model.subheadline != nil {
-                            Text(model.subheadline!)
+                        if let subheadline = model.subheadline {
+                            Text(subheadline)
                                 .font(.body)
                                 .foregroundColor(themeManager.color(for: .primary2))
                                 .lineLimit(2)
                                 .fixedSize(horizontal: false, vertical: true)
                         }
-                        if model.footnote != nil {
-                            Text(model.footnote!)
+                        if let footnote = model.footnote {
+                            Text(footnote)
                                 .font(.subheadline)
                                 .foregroundColor(themeManager.color(for: .primary2))
                                 .lineLimit(5)
@@ -62,8 +62,8 @@ struct ObjectCardMessageView: View {
                         if let status = model.status {
                             ItemStatus(status: status)
                         }
-                        if model.substatus != nil {
-                            Text(model.substatus!)
+                        if let substatus = model.substatus {
+                            Text(substatus)
                                 .font(.subheadline)
                                 .foregroundColor(themeManager.color(for: .primary2))
                         }
@@ -98,22 +98,23 @@ struct ObjectCardMessageView: View {
 #if DEBUG
     struct ObjectCardMessageView_Previews: PreviewProvider {
         static var previews: some View {
-            ObjectCardMessageView(model: UIModelDataContent(text: "text1", list: nil, form: nil, picture: nil, video: nil,
-                                                            header: UIModelDataHeader(title: UIModelDataValue(value: "title", dataType: UIModelData.ValueType.text.rawValue, rawValue: nil,
-                                                                                                              label: nil,
-                                                                                                              valueState: nil),
-                                                                                      subtitle: UIModelDataValue(value: "subtitle", dataType: UIModelData.ValueType.text.rawValue,
-                                                                                                                 rawValue: nil,
-                                                                                                                 label: nil,
-                                                                                                                 valueState: nil),
-                                                                                      description: UIModelDataValue(value: "desc", dataType: UIModelData.ValueType.text.rawValue,
-                                                                                                                    rawValue: nil,
-                                                                                                                    label: nil,
-                                                                                                                    valueState: nil)),
-                                                            buttons: [
-                                                                UIModelDataAction("b1", "b1", .text),
-                                                                UIModelDataAction("b2", "b2", .text)
-                                                            ])).environmentObject(ThemeManager.shared)
+            Group {
+                ObjectCardMessageView(model: UIModelDataContent(text: "text1", list: nil, form: nil, picture: nil, video: nil,
+                                                                header: UIModelDataHeader(options: .all),
+                                                                buttons: [
+                                                                    UIModelDataAction("b1", "b1", .text),
+                                                                    UIModelDataAction("b2", "b2", .text)
+                                                                ]))
+
+                ObjectCardMessageView(model: UIModelDataContent(text: "text1", list: nil, form: nil, picture: nil, video: nil,
+                                                                header: UIModelDataHeader(options: [.description, .status1]),
+                                                                buttons: [
+                                                                    UIModelDataAction("b1", "b1", .text),
+                                                                    UIModelDataAction("b2", "b2", .text)
+                                                                ]))
+            }
+            .environmentObject(ThemeManager.shared)
+            .previewLayout(.sizeThatFits)
         }
     }
 #endif


### PR DESCRIPTION
Do not show a dash ('-') as superfluous placeholder in case a missing
value (e.g. subtitle) is missing. This change does not introduce empty
space placeholders. The rule is that header type content moves up and
takes that position.

<img width="666" alt="Examples" src="https://user-images.githubusercontent.com/4176826/161326793-6b3cbe8c-5f51-4fd0-b113-9fb3728085cb.png">

